### PR TITLE
Add support for optionally supplying an ROI BED file to limit the mpileup.

### DIFF
--- a/cwl_helper.sh
+++ b/cwl_helper.sh
@@ -3,9 +3,9 @@
 set -o errexit
 set -o nounset
 
-if [ $# -ne 3 ]
+if [ $# -lt 3 ]
 then
-    echo "Usage: $0 [TUMOR_BAM] [NORMAL_BAM] [REFERENCE]"
+    echo "Usage: $0 [TUMOR_BAM] [NORMAL_BAM] [REFERENCE] [roi_bed?]"
     exit 1
 fi
 
@@ -14,8 +14,19 @@ NORMAL_BAM="$2"
 REFERENCE="$3"
 OUTPUT="${HOME}/output"
 
-java -jar /opt/varscan/VarScan.jar somatic \
-    <(/usr/bin/samtools mpileup --no-baq -f "$REFERENCE" "$NORMAL_BAM" "$TUMOR_BAM") \
-    $OUTPUT \
-    --mpileup 1 \
-    --output-vcf
+if [ -z ${4+x} ]
+then
+    #run without ROI
+    java -jar /opt/varscan/VarScan.jar somatic \
+        <(/usr/bin/samtools mpileup --no-baq -f "$REFERENCE" "$NORMAL_BAM" "$TUMOR_BAM") \
+        $OUTPUT \
+        --mpileup 1 \
+        --output-vcf
+else
+    ROI_BED="$4"
+    java -jar /opt/varscan/VarScan.jar somatic \
+        <(/usr/bin/samtools mpileup --no-baq -l "$ROI_BED" -f "$REFERENCE" "$NORMAL_BAM" "$TUMOR_BAM") \
+        $OUTPUT \
+        --mpileup 1 \
+        --output-vcf
+fi


### PR DESCRIPTION
This is part of genome/arvados_trial#42.